### PR TITLE
made a separate "create_hackpad" function that accepts title and contents

### DIFF
--- a/hackpad_api/hackpad.py
+++ b/hackpad_api/hackpad.py
@@ -17,12 +17,16 @@ class Hackpad(object):
     self.consumer_secret = consumer_secret
     return
 
-  def create_new_hackpad(self, asUser='', content_type='text/plain'):
+  def create_blank_hackpad(self, asUser='', content_type='text/plain'):
+    return create_hackpad('Hackpad Title', 'Auto-generated Hackpad contents.', 
+                            asUser, content_type)
+
+  def create_hackpad(self, title, content, asUser='', content_type='text/plain'):
     api_link = 'pad/create'
     params = {}
     if asUser != '':
       params['asUser'] = asUser
-    return self.do_api_request(api_link, 'POST', params, 'Hackpad Title\nHackpad contents.', content_type)
+    return self.do_api_request(api_link, 'POST', params, '%s\n%s' % (title, content), content_type)
 
   def get_pad_content(self, padId, revision='', response_format='txt', asUser=''):
     api_link = 'pad/%s/content' % padId


### PR DESCRIPTION
Hey, I saw that there was no existing function for making a new hackpad and at the same time setting its contents, so I pulled a `create_hackpad` function out of the old `create_new_hackpad`. 

There is now also a `create_blank_hackpad`, which does the same thing as the old `create_new_hackpad`, by invoking the lower level function with the appropriate parameters.
