### PR TITLE
Fix get_pad_content.

### DIFF
--- a/hackpad_api/hackpad.py
+++ b/hackpad_api/hackpad.py
@@ -28,11 +28,8 @@ class Hackpad(object):
       params['asUser'] = asUser
     return self.do_api_request(api_link, 'POST', params, '%s\n%s' % (title, content), content_type)
 
-  def get_pad_content(self, padId, revision='', response_format='txt', asUser=''):
-    api_link = 'pad/%s/content' % padId
-    if revision != '':
-      api_link += revision
-    api_link += '.%s' % response_format
+  def get_pad_content(self, padId, revision='latest', response_format='txt', asUser=''):
+    api_link = 'pad/%s/content/%s.%s' % (padId, revision, response_format)
     params = {}
     if asUser != '':
       params['asUser'] = asUser


### PR DESCRIPTION
Earlier this year, Hackpad silently changed their API to require a revision, even though it is listed as optional.

Without a revision, calls to get_pad_content return the HTML and JS of a page reporting a 500 error. The error behavior (and fix) is demonstrated by::

    import hackpad
    t = hackpad.Hackpad(subdomain, consumer_key, consumer_secret)
    print t.get_pad_content(pad_id)
